### PR TITLE
Bump Faraday version

### DIFF
--- a/nuorder.gemspec
+++ b/nuorder.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'vcr', '~> 2.9.3'
   spec.add_development_dependency 'dotenv', '~> 1.0.2'
 
-  spec.add_runtime_dependency 'faraday', '~> 0.9.1'
+  spec.add_runtime_dependency 'faraday', '>= 0.9.1'
   spec.add_runtime_dependency 'excon', '>= 0.45.3'
   spec.add_runtime_dependency 'faraday_middleware-multi_json', '~> 0.0.6'
 end


### PR DESCRIPTION
springboardretail/springboard-retail#10353 depends on this because of a conflicts with BigCommerce gem which depends on faraday (~> 0.11).